### PR TITLE
post-install.sh bug starts gitea as root not git

### DIFF
--- a/CONTROL/post-install.sh
+++ b/CONTROL/post-install.sh
@@ -18,7 +18,8 @@ docker create -i -t --name=$GITEA_CONTAINER \
   --env GITEA__server__PROTOCOL='https' \
   --env GITEA__server__CERT_FILE='/ssl/ssl.crt' \
   --env GITEA__server__KEY_FILE='/ssl/ssl.key' \
-  --env USER_UID=0 \
+  --env USER_UID=1000 \
+  --env USER_GID=1000 \
   --restart=unless-stopped \
   --volume $GITEA_DATA_PATH:/data \
   --volume /usr/builtin/etc/certificate/:/ssl/:ro \


### PR DESCRIPTION
gitea docker image should never be started as root user.
It should be started under git user as described in https://docs.gitea.io/en-us/install-with-docker/#basics