### PR TITLE
Allow Gitea to be install on other volumes

### DIFF
--- a/CONTROL/description-fr.txt
+++ b/CONTROL/description-fr.txt
@@ -24,7 +24,7 @@ Il est conseillé d'utiliser un serveur SMTP pour sécuriser Gitea et tenir info
 En bas de la page de configuration, vous trouverez la section de configuration du compte administrateur, configurez-le correctement.
 
 (-) Si vous échouez à l'installation...
-Eteignez l'application et supprimez le dossier "/volume1/Docker/Gitea", puis démarrez l'application et répétez la configuration.
+Eteignez l'application et supprimez le dossier "/share/Docker/Gitea", puis démarrez l'application et répétez la configuration.
 
 
 [PORTs]
@@ -32,7 +32,7 @@ Gitea expose le port HTTPS 3100-tcp et le port SSH 3122-tcp sur votre serveur.
 
 
 [FILES DE CONFIGURATION]
-Les fichiers de configuration de Gitea sont disponibles dans le dossier : "/volume1/Docker/Gitea" le fichier de configuration principal est disponible dans "./gitea/conf/app.ini". Il est nécessaire de redémarrer Gitea pour enregistrer les changements.
+Les fichiers de configuration de Gitea sont disponibles dans le dossier : "/share/Docker/Gitea" le fichier de configuration principal est disponible dans "./gitea/conf/app.ini". Il est nécessaire de redémarrer Gitea pour enregistrer les changements.
 
 
 [GITHUB]

--- a/CONTROL/description.txt
+++ b/CONTROL/description.txt
@@ -24,7 +24,7 @@ It is advisable to use an SMTP server to secure Gitea and keep your development 
 At the bottom of the configuration page you will find the administrator account configuration section, set it up properly.
 
 (-) If you fail the install...
-Turn off the application and delete the "/volume1/Docker/Gitea" folder, then start the application and repeat the configuration.
+Turn off the application and delete the "/share/Docker/Gitea" folder, then start the application and repeat the configuration.
 
 
 [PORTs]
@@ -32,7 +32,7 @@ Gitea exposes HTTPS port 3100-tcp and SSH port 3122-tcp on your server.
 
 
 [CONFIG FILES]
-Gitea configuration files are available in the folder: "/volume1/Docker/Gitea" the main configuration file is available in "./gitea/conf/app.ini". It is necessary to restart Gitea to save the changes.
+Gitea configuration files are available in the folder: "/share/Docker/Gitea" the main configuration file is available in "./gitea/conf/app.ini". It is necessary to restart Gitea to save the changes.
 
 
 [GITHUB]

--- a/CONTROL/post-install.sh
+++ b/CONTROL/post-install.sh
@@ -4,7 +4,7 @@ echo "gitea-adm: --== post-install ==--"
 
 # Environment variables
 GITEA_VERSION=$(cat $APKG_PKG_DIR/gitea_version)
-GITEA_DATA_PATH='/volume1/Docker/Gitea'
+GITEA_DATA_PATH='/share/Docker/Gitea'
 GITEA_CONFIG_PATH='/gitea/conf'
 GITEA_CONTAINER=Gitea
 GITEA_UID=999

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ __:warning: This application is not an Android application !__
 
 ## Configuration folder
 
-This application will create a folder in `/volume1/Docker/Gitea`, this folder will contain all configuration files, and the embedded database if you use it.
+This application will create a folder in `/share/Docker/Gitea`, this folder will contain all configuration files, and the embedded database if you use it.
 
 ## Configuration
 


### PR DESCRIPTION
I was trying to move my gitea repos to a different volume, but couldn't due to the hardcoded /volume1

This allows the gitea folder to be in another volume, whatever volume the Docker share is on.

This is how I learned where to put the new path:

From [SyncThing Asustor](https://www.asustor.com/en/app_central/app_detail?id=1091&type=&model=)

> ...
>  Note:
> 1. The default folder '/config' of Syncthing binds to '/share/Docker/Syncthing/config'.
> ...